### PR TITLE
Generating series

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,8 +44,8 @@
 		</dependency>
 		<dependency>
 			<groupId>org.apache.spark</groupId>
-			<artifactId>spark-core_2.11</artifactId>
-			<version>2.2.0</version>
+			<artifactId>spark-core_2.12</artifactId>
+			<version>2.4.0</version>
 			<scope>provided</scope>
 			<exclusions>
 				<exclusion>
@@ -56,8 +56,8 @@
 		</dependency>
 		<dependency>
 			<groupId>org.apache.spark</groupId>
-			<artifactId>spark-sql_2.11</artifactId>
-			<version>2.2.0</version>
+			<artifactId>spark-sql_2.12</artifactId>
+			<version>2.4.0</version>
 			<scope>provided</scope>
 			<exclusions>
 				<exclusion>
@@ -66,6 +66,33 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
+		<dependency>
+			<groupId>com.thoughtworks.paranamer</groupId>
+			<artifactId>paranamer</artifactId>
+			<version>2.8</version>
+		</dependency>
+		<dependency>
+			<groupId>org.codehaus.janino</groupId>
+			<artifactId>janino</artifactId>
+			<version>3.0.9</version> <!-- Ensure this matches the version needed by Spark -->
+			<exclusions>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-log4j12</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+        <dependency>
+            <groupId>org.codehaus.janino</groupId>
+            <artifactId>commons-compiler</artifactId>
+			<version>3.0.9</version>
+			<exclusions>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-log4j12</artifactId>
+				</exclusion>
+			</exclusions>
+        </dependency>
 		<dependency>
 			<groupId>com.googlecode.json-simple</groupId>
 			<artifactId>json-simple</artifactId>
@@ -76,17 +103,6 @@
 		    <artifactId>json</artifactId>
 		    <version>20170516</version>
 		</dependency>
-        <dependency>
-            <groupId>org.codehaus.janino</groupId>
-            <artifactId>commons-compiler</artifactId>
-			<version>2.7.8</version>
-			<exclusions>
-				<exclusion>
-					<groupId>org.slf4j</groupId>
-					<artifactId>slf4j-log4j12</artifactId>
-				</exclusion>
-			</exclusions>
-        </dependency>
 		<dependency>
 			<groupId>com.amazonaws</groupId>
 			<artifactId>aws-java-sdk</artifactId>


### PR DESCRIPTION
(2hrs) Generating series in spark sql requires version update, sequence is supported since version [2.4.0](https://spark.apache.org/docs/3.5.1/api/sql/#sequence)

this changes requires to run:
`mvn clean install` to update the dependencies tree and then `mvn spring-boot:run` to run the server