### PR TITLE
SparkSQL is not allowing to visualize the London dataset

### DIFF
--- a/src/main/java/com/aktiun/adt/spark/provider/ApplicationConfig.java
+++ b/src/main/java/com/aktiun/adt/spark/provider/ApplicationConfig.java
@@ -87,7 +87,9 @@ public class ApplicationConfig {
 		}
 
 		// Create new Spark Session
-		SparkSession sparkSession = SparkSession.builder().sparkContext(createJavaSparkContext().sc())
+		SparkSession sparkSession = SparkSession.builder()
+				.sparkContext(createJavaSparkContext().sc())
+				.config("spark.sql.legacy.timeParserPolicy", "LEGACY")
 				.appName("Spark SQL Provider").getOrCreate();
 
 		createCsvDatasets(sparkSession);


### PR DESCRIPTION
SparkSQL is not allowing to visualize the London dataset.  STR: 1. Open the London dataset in SparkSQL.  Actual: error below.  It seems it is working ok with timestamps but not with date fields. Expected: It should behave the same as the Databricks London dataset.
Error: Job aborted due to stage failure: Task 0 in stage 18.0 failed 1 times, most recent failure: Lost task 0.0 in stage 18.0 (TID 18) (192.168.1.162 executor driver): org.apache.spark.SparkUpgradeException: [INCONSISTENT_BEHAVIOR_CROSS_VERSION.PARSE_DATETIME_BY_NEW_PARSER] You may get a different result due to the upgrading to Spark >= 3.0: Fail to parse '1/1/2017' in the new parser. You can set "spark.sql.legacy.timeParserPolicy" to "LEGACY" to restore the behavior before Spark 3.0, or set to "CORRECTED" and treat it as an invalid datetime string. at org.apache.spark.sql.errors.ExecutionErrors.failToParseDateTimeInNewParserError(ExecutionErrors.scala:54) at 
